### PR TITLE
Use `type=gha` as caches for dockerimages.

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -74,13 +74,6 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       -
-        name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ matrix.distro }}-${{ matrix.tag }}
-          restore-keys: ${{ matrix.distro }}-${{ matrix.tag }}
-      -
         name: Login to DockerHub
         uses: docker/login-action@v2
         with:
@@ -96,5 +89,5 @@ jobs:
           file: ${{ matrix.distro }}-${{ matrix.tag }}/Dockerfile
           push: ${{ github.event_name == 'push' }}
           tags: pizzafactory0contorno/piatto:${{ matrix.distro }}-${{ matrix.tag }},pizzafactory0contorno/piatto:${{ matrix.tag }}-${{ matrix.distro }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>
