### PR TITLE
Reduce target archs for debian-10.

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -57,7 +57,7 @@ jobs:
             platforms: linux/386, linux/amd64, linux/arm/v7, linux/arm64/v8, linux/mips64le, linux/ppc64le, linux/s390x
           - tag: '10'
             distro: debian
-            platforms: linux/386, linux/amd64, linux/arm/v6, linux/arm/v7, linux/arm64/v8, linux/ppc64le, linux/s390x
+            platforms: linux/386, linux/amd64, linux/arm/v7, linux/arm64/v8
           - tag: '10.1'
             distro: debian
             platforms: linux/386, linux/amd64, linux/arm/v6, linux/arm/v7, linux/arm64/v8, linux/ppc64le, linux/s390x


### PR DESCRIPTION
As they are not supported by an upstream.

Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>
